### PR TITLE
Fallback context

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,8 @@ lazy val commonSettings = testSettings ++ /*testCoverageSettings ++ */Seq (
     "io.sphere.sdk.jvm" % "sphere-play-2_4-java-client_2.10" % sphereJvmSdkVersion,
     "io.sphere" % "sphere-sunrise-design" % "0.2.2",
     "org.webjars" % "webjars-play_2.10" % "2.4.0-1",
-    "com.github.jknack" % "handlebars" % "2.2.1"
+    "com.github.jknack" % "handlebars" % "2.2.3",
+    "com.github.jknack" % "handlebars-jackson2" % "2.2.3"
   ),
   dependencyOverrides ++= Set (
     "com.google.guava" % "guava" % "18.0",

--- a/build.sbt
+++ b/build.sbt
@@ -54,8 +54,7 @@ lazy val commonSettings = testSettings ++ /*testCoverageSettings ++ */Seq (
     "io.sphere.sdk.jvm" % "sphere-play-2_4-java-client_2.10" % sphereJvmSdkVersion,
     "io.sphere" % "sphere-sunrise-design" % "0.2.2",
     "org.webjars" % "webjars-play_2.10" % "2.4.0-1",
-    "com.github.jknack" % "handlebars" % "2.2.3",
-    "com.github.jknack" % "handlebars-jackson2" % "2.2.3"
+    "com.github.jknack" % "handlebars" % "2.2.3"
   ),
   dependencyOverrides ++= Set (
     "com.google.guava" % "guava" % "18.0",

--- a/common/app/common/templates/HandlebarsTemplateService.java
+++ b/common/app/common/templates/HandlebarsTemplateService.java
@@ -1,26 +1,38 @@
 package common.templates;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.context.MapValueResolver;
+import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
 import com.github.jknack.handlebars.io.TemplateLoader;
+
 import common.pages.PageData;
 import play.Logger;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
 
 public final class HandlebarsTemplateService implements TemplateService {
     private final Handlebars handlebars;
+    private final List<TemplateLoader> fallbackContexts;
 
-    private HandlebarsTemplateService(final Handlebars handlebars) {
+    private HandlebarsTemplateService(final Handlebars handlebars, final List<TemplateLoader> fallbackContexts) {
         this.handlebars = handlebars;
+        this.fallbackContexts = fallbackContexts;
     }
 
     @Override
     public String render(final String templateName, final PageData pageData) {
         final Template template = compileTemplate(templateName);
-        final Context context = buildContext(pageData);
+        final Context context = buildContext(pageData, templateName);
         try {
             Logger.debug("Rendering template " + templateName);
             return template.apply(context);
@@ -29,9 +41,14 @@ public final class HandlebarsTemplateService implements TemplateService {
         }
     }
 
-    public static HandlebarsTemplateService of(final TemplateLoader... loaders) {
+    public static TemplateService of(final List<TemplateLoader> templateLoaders) {
+        return of(templateLoaders, emptyList());
+    }
+
+    public static TemplateService of(final List<TemplateLoader> templateLoaders, final List<TemplateLoader> fallbackContexts) {
+        final TemplateLoader[] loaders = templateLoaders.toArray(new TemplateLoader[templateLoaders.size()]);
         final Handlebars handlebars = new Handlebars().with(loaders);
-        return new HandlebarsTemplateService(handlebars);
+        return new HandlebarsTemplateService(handlebars, fallbackContexts);
     }
 
     private Template compileTemplate(final String templateName) {
@@ -42,17 +59,38 @@ public final class HandlebarsTemplateService implements TemplateService {
         }
     }
 
-    private Context buildContext(final PageData pageData) {
+    private Context buildContext(final PageData pageData, final String templateName) {
         // TODO Use resolver with cache on production
-        return Context.newBuilder(pageData)
-                .resolver(NonCachedJavaBeanValueResolver.INSTANCE)
-                .build();
+        Context.Builder builder = Context.newBuilder(pageData)
+                .resolver(NonCachedJavaBeanValueResolver.INSTANCE, MapValueResolver.INSTANCE);
+        for (final TemplateLoader fallbackContext : fallbackContexts) {
+            final Optional<Map<String, ?>> map = buildFallbackContext(fallbackContext, templateName);
+            if (map.isPresent()) {
+                builder = builder.combine(map.get());
+            }
+        }
+        return builder.build();
     }
 
+    private Optional<Map<String, ?>> buildFallbackContext(final TemplateLoader fallbackLoader, final String templateName) {
+        return getResource(fallbackLoader, templateName).map(stream -> {
+            try {
+                return new ObjectMapper().readValue(stream, HashMap.class);
+            } catch (IOException e) {
+                Logger.error("Could not read fallback context", e);
+                return null;
+            }
+        });
+    }
 
-    public static TemplateService of(final List<TemplateLoader> templateLoaders) {
-        final TemplateLoader[] templateLoadersArray =
-                templateLoaders.toArray(new TemplateLoader[templateLoaders.size()]);
-        return of(templateLoadersArray);
+    private Optional<InputStream> getResource(final TemplateLoader fallbackLoader, final String templateName) {
+        final InputStream resource;
+        if (fallbackLoader instanceof ClassPathTemplateLoader) {
+            final String path = fallbackLoader.resolve(templateName).replaceAll("^/?(.*)\\.hbs$", "$1.json");
+            resource = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
+        } else {
+            throw new RuntimeException("Invalid fallback context type, only classpath supported");
+        }
+        return Optional.ofNullable(resource);
     }
 }

--- a/common/app/common/templates/NonCachedMethodValueResolver.java
+++ b/common/app/common/templates/NonCachedMethodValueResolver.java
@@ -21,7 +21,8 @@ public class NonCachedMethodValueResolver extends NonCachedMemberValueResolver<M
 
     @Override
     public boolean matches(final Method method, final String name) {
-        return isPublic(method) && method.getName().equals(name);
+        int parameterCount = method.getParameterTypes().length;
+        return isPublic(method) && method.getName().equals(name) && parameterCount == 0;
     }
 
     @Override

--- a/common/test/common/templates/HandlebarsTemplateServiceTest.java
+++ b/common/test/common/templates/HandlebarsTemplateServiceTest.java
@@ -1,15 +1,19 @@
 package common.templates;
 
 import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
+import com.github.jknack.handlebars.io.TemplateLoader;
 import common.pages.*;
 import org.junit.Test;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class HandlebarsTemplateServiceTest {
-    private static final ClassPathTemplateLoader DEFAULT_LOADER = new ClassPathTemplateLoader("/templates");
-    private static final ClassPathTemplateLoader OVERRIDE_LOADER = new ClassPathTemplateLoader("/templates/override");
+    private static final TemplateLoader DEFAULT_LOADER = new ClassPathTemplateLoader("/templates");
+    private static final TemplateLoader OVERRIDE_LOADER = new ClassPathTemplateLoader("/templates/override");
+    private static final TemplateLoader WRONG_LOADER = new ClassPathTemplateLoader("/templates/wrong");
 
     @Test
     public void rendersTemplateWithPartial() throws Exception {
@@ -17,7 +21,8 @@ public class HandlebarsTemplateServiceTest {
         assertThat(html).contains("<title>foo</title>")
                 .contains("<h1>bar</h1>")
                 .contains("<h2></h2>")
-                .contains("<p>default partial</p>");
+                .contains("<p>default partial</p>")
+                .contains("<ul></ul>");
     }
 
     @Test
@@ -42,12 +47,36 @@ public class HandlebarsTemplateServiceTest {
                 .isInstanceOf(TemplateNotFoundException.class);
     }
 
-    private HandlebarsTemplateService handlebarsWithOverride() {
-        return HandlebarsTemplateService.of(OVERRIDE_LOADER, DEFAULT_LOADER);
+    @Test
+    public void usesFallbackContextWhenMissingData() throws Exception {
+        final String html = handlebarsWithFallbackContext(DEFAULT_LOADER).render("template", pageDataWithTitleAndMessage());
+        assertThat(html).contains("<title>foo</title>")
+                .contains("<h1>bar</h1>")
+                .contains("<h2>fallback unknown</h2>")
+                .contains("<p>default partial</p>")
+                .contains("<ul><li>fallback foo</li><li>fallback bar</li></ul>");
     }
 
-    private HandlebarsTemplateService handlebars() {
-        return HandlebarsTemplateService.of(DEFAULT_LOADER);
+    @Test
+    public void failsSilentlyWhenFallbackContextNotFound() throws Exception {
+        final String html = handlebarsWithFallbackContext(WRONG_LOADER).render("template", pageDataWithTitleAndMessage());
+        assertThat(html).contains("<title>foo</title>")
+                .contains("<h1>bar</h1>")
+                .contains("<h2></h2>")
+                .contains("<p>default partial</p>")
+                .contains("<ul></ul>");
+    }
+
+    private TemplateService handlebars() {
+        return HandlebarsTemplateService.of(singletonList(DEFAULT_LOADER));
+    }
+
+    private TemplateService handlebarsWithOverride() {
+        return HandlebarsTemplateService.of(asList(OVERRIDE_LOADER, DEFAULT_LOADER));
+    }
+
+    private TemplateService handlebarsWithFallbackContext(final TemplateLoader fallbackContextLoader) {
+        return HandlebarsTemplateService.of(singletonList(DEFAULT_LOADER), singletonList(fallbackContextLoader));
     }
 
     private PageData pageDataWithTitleAndMessage() {

--- a/common/test/resources/logback-test.xml
+++ b/common/test/resources/logback-test.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
 
-    <root level="info">
+    <root level="off">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/common/test/resources/templates/template.hbs
+++ b/common/test/resources/templates/template.hbs
@@ -4,7 +4,8 @@
     </head>
     <body>
         <h1>{{message}}</h1>
-        <h2>{{unknown}}</h2>
+        <h2>{{some.unknown}}</h2>
         <p>{{>partial}} partial</p>
+        <ul>{{#each deep.deeper.deepest}}<li>{{this}}</li>{{/each}}</ul>
     </body>
 </html>

--- a/common/test/resources/templates/template.json
+++ b/common/test/resources/templates/template.json
@@ -1,0 +1,13 @@
+{
+  "some":{
+    "unknown":"fallback unknown"
+  },
+  "deep":{
+    "deeper":{
+      "deepest":[
+        "fallback foo",
+        "fallback bar"
+      ]
+    }
+  }
+}

--- a/common/test/resources/templates/wrong/template.json
+++ b/common/test/resources/templates/wrong/template.json
@@ -1,0 +1,1 @@
+invalid json

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -5,8 +5,8 @@
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret="TsLWj4[^1N<7nrI/>EkyPDTO[dnh<7_R[j;cN0:lGK6Mm`0048C@3PK]4KR6HobLhu"
-application.secret=${?APPLICATION_SECRET}
+play.crypto.secret="TsLWj4[^1N<7nrI/>EkyPDTO[dnh<7_R[j;cN0:lGK6Mm`0048C@3PK]4KR6HobLhu"
+play.crypto.secret=${?APPLICATION_SECRET}
 
 # The application configuration
 # ~~~~~
@@ -19,8 +19,11 @@ play.i18n.langs=["en"]
 play.modules.enabled += "inject.ProductionModule"
 
 handlebars.templateLoaders=[
-  {"type":"classpath", "path":"/META-INF/resources/webjars/templates"},
-  {"type":"file", "path":"app/assets/templates"}
+  {"type":"file", "path":"app/assets/templates"},
+  {"type":"classpath", "path":"/META-INF/resources/webjars/templates"}
+]
+handlebars.fallbackContexts=[
+  {"type":"classpath", "path":"/META-INF/resources/webjars/templates"}
 ]
 
 include "dev"


### PR DESCRIPTION
@schleichardt @peter-gerhard @butenkor review please

With this functionality the data coming from the Page classes is combined with other sources, doing a fallback effect. In particular, we are using this to use the JSON coming from the sphere-sunrise-design as a fallback when we still don't have the feature implemented in Sunrise, in order to present a filled template all the time.

Some issues:
- Currently those parts of the template coming using a {{#with }} are not being rendered for some reason. Will have to report to the dev of Handlebars Java.
- I chose to transform the JSON file to a Map because Handlebars Java only allows Maps for the `combine` function. I've tried to pass the JSON as parent context and works the same, but I feel combine is better oriented to the functionality we are using, while parent context is mostly used to save the context on nested data. Probably inside uses the same functionality, but it is a semantic issue.
- I'm using the TemplateLoader as a way to configure the path, so that we use the same system as we do with the Handlebars TemplateLoaders. Actually the JSON file must be called the same and be equivalent, except for the extension, so technically is not that wrong. If you think it's better to change it, please suggest a better option and I'll change it.