### PR TITLE
Facet classes applied

### DIFF
--- a/move-to-sdk/test/io/sphere/sdk/facets/FlexibleSelectFacetTest.java
+++ b/move-to-sdk/test/io/sphere/sdk/facets/FlexibleSelectFacetTest.java
@@ -1,5 +1,6 @@
 package io.sphere.sdk.facets;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.sphere.sdk.json.SphereJsonUtils;
 import io.sphere.sdk.products.ProductProjection;
@@ -14,6 +15,7 @@ import play.libs.Json;
 import java.util.List;
 
 import static io.sphere.sdk.facets.DefaultFacetType.SORTED_SELECT;
+import static io.sphere.sdk.json.SphereJsonUtils.readObjectFromResource;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,33 +106,7 @@ public class FlexibleSelectFacetTest {
         assertThat(facet.withSearchResult(searchResult()).getFacetResult()).contains(FACET_RESULT_WITH_THREE_TERMS);
     }
 
-    @SuppressWarnings("unchecked")
     private PagedSearchResult<ProductProjection> searchResult() {
-        final String json = "{" +
-                        "  \"facets\": {" +
-                        "    \"categories.id\": {" +
-                        "      \"type\": \"terms\"," +
-                        "      \"missing\": 5," +
-                        "      \"total\": 60," +
-                        "      \"other\": 0," +
-                        "      \"terms\": [" +
-                        "        { " +
-                        "          \"term\": \"one\", " +
-                        "          \"count\": 30 " +
-                        "        }," +
-                        "        { " +
-                        "          \"term\": \"two\", " +
-                        "          \"count\": 20 " +
-                        "        }," +
-                        "        { " +
-                        "          \"term\": \"three\", " +
-                        "          \"count\": 10 " +
-                        "        }" +
-                        "      ]" +
-                        "    }" +
-                        "  }" +
-                        "}";
-        final JsonNode node = Json.parse(json);
-        return SphereJsonUtils.readObject(node, PagedSearchResult.class);
+        return readObjectFromResource("pagedSearchResult.json", new TypeReference<PagedSearchResult<ProductProjection>>() {});
     }
 }


### PR DESCRIPTION
@schleichardt @butenkor please review.

It's the continuation from the previous Facet PR. Before it was just the classes with no real application. Now they are used to display the facets in the POP, so they underwent some big changes.
As now they are working, they are also fully tested and documented.

Some considerations:

- To avoid making the PR longer, the `ProductOverviewPageController` is not optimized. Also, it needs some bigger picture to extract properly the methods, that's why I simply put everything in there. Later, along with the `ProductDetailPageController`, it will be improved.

- Colors and sizes need some more work, like getting the enum values from the Product Type to display it properly (i.e. show the correct localized name, in the case of colors). That will be the work of a future PR.

- I have overridden the `filters-sidebar.hbs` template because the implementation in `sunrise-design` is not generic enough. Once I merge the PR I will apply this changes to `sunrise-design` as it also need some CSS/JS modification (which are wrote down in `main.css`).