### PR TITLE
Enable country and language in configuration as override, closes #220

### DIFF
--- a/app/controllers/ApplicationController.java
+++ b/app/controllers/ApplicationController.java
@@ -18,19 +18,17 @@ import javax.inject.Singleton;
 public final class ApplicationController extends Controller {
     private final Injector injector;
     private final SetupController setupController;
-    private final ProjectContext projectContext;
-
 
     @Inject
-    public ApplicationController(final Injector injector, final SetupController setupController, final ProjectContext projectContext) {
+    public ApplicationController(final Injector injector, final SetupController setupController) {
         this.injector = injector;
         this.setupController = setupController;
-        this.projectContext = projectContext;
     }
 
     public F.Promise<Result> index() {
         return setupController.handleOrFallback(() -> {
             final HomeController homeController = injector.instanceOf(HomeController.class);
+            final ProjectContext projectContext = injector.instanceOf(ProjectContext.class);
             final String defaultLanguage = projectContext.defaultLanguage().toLanguageTag();
             return homeController.show(defaultLanguage);
         });

--- a/app/controllers/ApplicationController.java
+++ b/app/controllers/ApplicationController.java
@@ -1,5 +1,6 @@
 package controllers;
 
+import common.contexts.ProjectContext;
 import play.inject.Injector;
 import play.libs.F;
 import play.mvc.Controller;
@@ -17,18 +18,21 @@ import javax.inject.Singleton;
 public final class ApplicationController extends Controller {
     private final Injector injector;
     private final SetupController setupController;
+    private final ProjectContext projectContext;
+
 
     @Inject
-    public ApplicationController(final Injector injector, final SetupController setupController) {
+    public ApplicationController(final Injector injector, final SetupController setupController, final ProjectContext projectContext) {
         this.injector = injector;
         this.setupController = setupController;
+        this.projectContext = projectContext;
     }
 
     public F.Promise<Result> index() {
         return setupController.handleOrFallback(() -> {
             final HomeController homeController = injector.instanceOf(HomeController.class);
-            final String languageTag = lang().code();
-            return homeController.show(languageTag);
+            final String defaultLanguage = projectContext.defaultLanguage().toLanguageTag();
+            return homeController.show(defaultLanguage);
         });
     }
 

--- a/app/inject/ProjectContextProvider.java
+++ b/app/inject/ProjectContextProvider.java
@@ -1,10 +1,12 @@
 package inject;
 
 import com.google.inject.Provider;
+import com.neovisionaries.i18n.CountryCode;
 import common.contexts.ProjectContext;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.projects.Project;
 import io.sphere.sdk.projects.queries.ProjectGet;
+import play.Configuration;
 import play.Logger;
 
 import javax.inject.Inject;
@@ -12,13 +14,18 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 class ProjectContextProvider implements Provider<ProjectContext> {
+    private static final String CONFIG_COUNTRIES = "application.countries";
+    private static final String CONFIG_LANGUAGES = "application.languages";
+    private final Configuration configuration;
     private final SphereClient client;
 
     @Inject
-    private ProjectContextProvider(final SphereClient client) {
+    private ProjectContextProvider(final Configuration configuration, final SphereClient client) {
+        this.configuration = configuration;
         this.client = client;
     }
 
@@ -26,13 +33,40 @@ class ProjectContextProvider implements Provider<ProjectContext> {
     public ProjectContext get() {
         try {
             final Project project = client.execute(ProjectGet.of()).toCompletableFuture().get();
+            final List<Locale> languages = getLanguages(project);
+            final List<CountryCode> countries = getCountries(project);
             Logger.debug("Provide ProjectContext:"
-                    + " Languages" + project.getLanguages() + ","
-                    + " Countries" + project.getCountries());
-            final List<Locale> languages = project.getLanguages().stream().map(Locale::forLanguageTag).collect(toList());
-            return ProjectContext.of(languages, project.getCountries());
+                    + " Languages" + languages + ","
+                    + " Countries" + countries);
+            return ProjectContext.of(languages, countries);
         } catch (ExecutionException | InterruptedException e) {
             throw new SunriseInitializationException("Could not fetch project information", e);
         }
+    }
+
+    private List<Locale> getLanguages(final Project project) {
+        final List<Locale> locales = configuration.getStringList(CONFIG_LANGUAGES, project.getLanguages())
+                .stream()
+                .map(Locale::forLanguageTag)
+                .collect(toList());
+        if (locales.isEmpty()) {
+            throw new SunriseInitializationException("No language defined, neither in project nor in configuration");
+        }
+        return locales;
+    }
+
+    private List<CountryCode> getCountries(final Project project) {
+        final List<CountryCode> countriesFromConfig = getCountriesFromConfig();
+        final List<CountryCode> countries = countriesFromConfig.isEmpty() ? project.getCountries() : countriesFromConfig;
+        if (countries.isEmpty()) {
+            throw new SunriseInitializationException("No country defined, neither in project nor in configuration");
+        }
+        return countries;
+    }
+
+    private List<CountryCode> getCountriesFromConfig() {
+        return configuration.getStringList(CONFIG_COUNTRIES, emptyList()).stream()
+                .map(CountryCode::valueOf)
+                .collect(toList());
     }
 }

--- a/app/inject/SunriseInitializationException.java
+++ b/app/inject/SunriseInitializationException.java
@@ -2,6 +2,10 @@ package inject;
 
 public class SunriseInitializationException extends RuntimeException {
 
+    public SunriseInitializationException(final String message) {
+        super(message);
+    }
+
     public SunriseInitializationException(final String message, final Throwable cause) {
         super(message, cause);
     }

--- a/app/inject/TemplateServiceProvider.java
+++ b/app/inject/TemplateServiceProvider.java
@@ -4,6 +4,7 @@ import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
 import com.github.jknack.handlebars.io.FileTemplateLoader;
 import com.github.jknack.handlebars.io.TemplateLoader;
 import com.google.inject.Provider;
+import common.contexts.ProjectContext;
 import common.templates.HandlebarsTemplateService;
 import common.templates.TemplateService;
 import play.Configuration;
@@ -11,44 +12,45 @@ import play.Logger;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Locale;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 class TemplateServiceProvider implements Provider<TemplateService> {
-    private static final String CONFIG_CACHE_ENABLED = "handlebars.cache.enabled";
     private static final String CONFIG_TEMPLATE_LOADERS = "handlebars.templateLoaders";
     private static final String CONFIG_FALLBACK_CONTEXTS = "handlebars.fallbackContexts";
-    private static final String CONFIG_LANGUAGES = "handlebars.i18n.langs";
+    private static final String CONFIG_CACHE_ENABLED = "handlebars.cache.enabled";
     private static final String CONFIG_BUNDLES = "handlebars.i18n.bundles";
-
     private static final String CLASSPATH_TYPE = "classpath";
     private static final String FILE_TYPE = "file";
     private static final String TYPE_ATTR = "type";
     private static final String PATH_ATTR = "path";
     private final Configuration configuration;
+    private final ProjectContext projectContext;
 
     @Inject
-    public TemplateServiceProvider(final Configuration configuration) {
+    public TemplateServiceProvider(final Configuration configuration, final ProjectContext projectContext) {
         this.configuration = configuration;
+        this.projectContext = projectContext;
     }
 
     @Override
     public TemplateService get() {
         final List<TemplateLoader> templateLoaders = initializeTemplateLoaders(CONFIG_TEMPLATE_LOADERS);
         final List<TemplateLoader> fallbackContexts = initializeTemplateLoaders(CONFIG_FALLBACK_CONTEXTS);
-        Logger.debug("Provide HandlebarsTemplateService: "
-                + templateLoaders.stream().map(TemplateLoader::getPrefix).collect(joining(", ")));
-
         final boolean cacheIsEnabled = configuration.getBoolean(CONFIG_CACHE_ENABLED, false);
-        Logger.debug(" with cache enabled: {}", cacheIsEnabled);
-
-        final List<String> languages = configuration.getStringList(CONFIG_LANGUAGES, emptyList());
+        final List<Locale> locales = projectContext.languages();
         final List<String> bundles = configuration.getStringList(CONFIG_BUNDLES, emptyList());
-        Logger.debug(" for languages {} and bundles {}", languages, bundles);
 
-        return HandlebarsTemplateService.of(templateLoaders, fallbackContexts, languages, bundles, cacheIsEnabled);
+        Logger.debug("Provide HandlebarsTemplateService: {}, cache enabled {}, languages {}, bundles {}",
+                templateLoaders.stream().map(TemplateLoader::getPrefix).collect(joining(", ")),
+                cacheIsEnabled,
+                locales,
+                bundles);
+
+        return HandlebarsTemplateService.of(templateLoaders, fallbackContexts, locales, bundles, cacheIsEnabled);
     }
 
     private List<TemplateLoader> initializeTemplateLoaders(final String configKey) {

--- a/common/app/common/contexts/ProjectContext.java
+++ b/common/app/common/contexts/ProjectContext.java
@@ -5,11 +5,15 @@ import com.neovisionaries.i18n.CountryCode;
 import java.util.List;
 import java.util.Locale;
 
+import static io.sphere.sdk.utils.IterableUtils.requireNonEmpty;
+
 public class ProjectContext {
     private final List<Locale> languages;
     private final List<CountryCode> countries;
 
     private ProjectContext(final List<Locale> languages, final List<CountryCode> countries) {
+        requireNonEmpty(languages);
+        requireNonEmpty(countries);
         this.languages = languages;
         this.countries = countries;
     }
@@ -20,6 +24,14 @@ public class ProjectContext {
 
     public List<CountryCode> countries() {
         return countries;
+    }
+
+    public Locale defaultLanguage() {
+        return languages.stream().findFirst().get();
+    }
+
+    public CountryCode defaultCountry() {
+        return countries.stream().findFirst().get();
     }
 
     public static ProjectContext of(final List<Locale> languages, final List<CountryCode> countries) {

--- a/common/app/common/templates/CustomI18nHelper.java
+++ b/common/app/common/templates/CustomI18nHelper.java
@@ -19,22 +19,22 @@ import static java.util.Objects.requireNonNull;
 final class CustomI18nHelper extends Base implements Helper<String> {
     private final Map<String, Map<String, Object>> languageBundleToYamlMap = new HashMap<>();
 
-    public CustomI18nHelper(final List<String> languages, final List<String> bundles) {
-        requireNonNull(languages);
+    public CustomI18nHelper(final List<Locale> locales, final List<String> bundles) {
+        requireNonNull(locales);
         requireNonNull(bundles);
-        for (final String language : languages) {
+        for (final Locale locale : locales) {
             final List<String> foundBundles = new LinkedList<>();
             final List<String> notFoundBundles = new LinkedList<>();
             for (final String bundle : bundles) {
                 try {
-                    final Map<String, Object> yamlContent = loadYamlForTranslationAndBundle(language, bundle);
-                    languageBundleToYamlMap.put(language + "/" + bundle, yamlContent);
+                    final Map<String, Object> yamlContent = loadYamlForTranslationAndBundle(locale, bundle);
+                    languageBundleToYamlMap.put(locale.toLanguageTag() + "/" + bundle, yamlContent);
                     foundBundles.add(bundle);
                 } catch (final IOException e){
                     notFoundBundles.add(bundle);
                 }
             }
-            Logger.info("handlebars-i18n: {}: loaded: '{}' failed: {}", language, foundBundles, notFoundBundles);
+            Logger.info("handlebars-i18n: {}: loaded: '{}' failed: {}", locale, foundBundles, notFoundBundles);
         }
     }
 
@@ -122,14 +122,14 @@ final class CustomI18nHelper extends Base implements Helper<String> {
         return (List<String>) options.context.get("locales");
     }
 
-    private static Map<String, Object> loadYamlForTranslationAndBundle(final String languageTag, final String bundle) throws IOException {
-        final String path = buildYamlPath(languageTag, bundle);
+    private static Map<String, Object> loadYamlForTranslationAndBundle(final Locale locale, final String bundle) throws IOException {
+        final String path = buildYamlPath(locale, bundle);
         final InputStream inputStream = getResourceAsStream(path);
         return loadYamlData(inputStream);
     }
 
-    private static String buildYamlPath(final String languageTag, final String bundle) {
-        return "META-INF/resources/webjars/locales/" + languageTag + "/" + bundle + ".yaml";
+    private static String buildYamlPath(final Locale locale, final String bundle) {
+        return "META-INF/resources/webjars/locales/" + locale.toLanguageTag() + "/" + bundle + ".yaml";
     }
 
     private static Map<String, Object> loadYamlData(final InputStream inputStream) throws IOException {

--- a/common/app/common/templates/HandlebarsTemplateService.java
+++ b/common/app/common/templates/HandlebarsTemplateService.java
@@ -44,16 +44,16 @@ public final class HandlebarsTemplateService implements TemplateService {
         }
     }
 
-    public static TemplateService of(final List<TemplateLoader> templateLoaders, final List<String> languages,
+    public static TemplateService of(final List<TemplateLoader> templateLoaders, final List<Locale> locales,
                                      final List<String> bundles, final boolean cachingIsEnabled) {
-        return of(templateLoaders, emptyList(), languages, bundles, cachingIsEnabled);
+        return of(templateLoaders, emptyList(), locales, bundles, cachingIsEnabled);
     }
 
     public static TemplateService of(final List<TemplateLoader> templateLoaders, final List<TemplateLoader> fallbackContexts,
-                                     final List<String> languages, final List<String> bundles, final boolean cachingIsEnabled) {
+                                     final List<Locale> locales, final List<String> bundles, final boolean cachingIsEnabled) {
         final TemplateLoader[] loaders = templateLoaders.toArray(new TemplateLoader[templateLoaders.size()]);
         final Handlebars handlebars = new Handlebars().with(loaders).infiniteLoops(true);
-        handlebars.registerHelper("i18n", new CustomI18nHelper(languages, bundles));
+        handlebars.registerHelper("i18n", new CustomI18nHelper(locales, bundles));
         handlebars.registerHelper("json", new HandlebarsJsonHelper<>());
         return new HandlebarsTemplateService(handlebars, fallbackContexts, cachingIsEnabled);
     }

--- a/common/test/common/templates/HandlebarsTemplateTest.java
+++ b/common/test/common/templates/HandlebarsTemplateTest.java
@@ -17,8 +17,7 @@ public class HandlebarsTemplateTest {
     private static final TemplateLoader DEFAULT_LOADER = new ClassPathTemplateLoader("/templates");
     private static final TemplateLoader OVERRIDE_LOADER = new ClassPathTemplateLoader("/templates/override");
     private static final TemplateLoader WRONG_LOADER = new ClassPathTemplateLoader("/templates/wrong");
-    private static final List<Locale> LOCALES = singletonList(Locale.ENGLISH);
-    private static final List<String> LANGUAGES = asList("en", "de");
+    private static final List<Locale> LOCALES = asList(Locale.ENGLISH, Locale.GERMAN);
     private static final List<String> BUNDLES = asList("translations", "home", "catalog", "checkout", "foo");
 
     @Test
@@ -119,15 +118,15 @@ public class HandlebarsTemplateTest {
     }
 
     private TemplateService handlebars() {
-        return HandlebarsTemplateService.of(singletonList(DEFAULT_LOADER), LANGUAGES, BUNDLES, false);
+        return HandlebarsTemplateService.of(singletonList(DEFAULT_LOADER), LOCALES, BUNDLES, false);
     }
 
     private TemplateService handlebarsWithOverride() {
-        return HandlebarsTemplateService.of(asList(OVERRIDE_LOADER, DEFAULT_LOADER), LANGUAGES, BUNDLES, false);
+        return HandlebarsTemplateService.of(asList(OVERRIDE_LOADER, DEFAULT_LOADER), LOCALES, BUNDLES, false);
     }
 
     private TemplateService handlebarsWithFallbackContext(final TemplateLoader fallbackContextLoader) {
-        return HandlebarsTemplateService.of(singletonList(DEFAULT_LOADER), singletonList(fallbackContextLoader), LANGUAGES, BUNDLES, false);
+        return HandlebarsTemplateService.of(singletonList(DEFAULT_LOADER), singletonList(fallbackContextLoader), LOCALES, BUNDLES, false);
     }
 
     private PageData pageDataWithTitleAndMessage() {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,48 +8,37 @@
 play.crypto.secret="TsLWj4[^1N<7nrI/>EkyPDTO[dnh<7_R[j;cN0:lGK6Mm`0048C@3PK]4KR6HobLhu"
 play.crypto.secret=${?APPLICATION_SECRET}
 
-# The application configuration
+# The enabled modules
 # ~~~~~
-application.settingsWidget.enabled=true
-
-sphere.countries=["DE","AT"]
-
-play.i18n.langs=["en", "de"]
-
 play.modules.enabled += "inject.CtpClientProductionModule"
 play.modules.enabled += "inject.CtpModelsProductionModule"
 play.modules.enabled += "inject.ApplicationProductionModule"
 
-productData.enabledAttributes=["size", "colorFreeDefinition"]
+# The application configuration
+# ~~~~~
+application.settingsWidget.enabled = true
 
+# overridden configuration from CTP project, default first
+#application.countries = ["DE", "US", "GB", "AT", "CH"]
+#application.languages = ["en", "de", "es"]
+
+productData.enabledAttributes = ["size", "colorFreeDefinition"]
+
+# handlebars config
 handlebars.cache.enabled = false
-
-handlebars.templateLoaders=[
+handlebars.templateLoaders = [
   {"type":"classpath", "path":"/templates"},
   {"type":"classpath", "path":"/META-INF/resources/webjars/templates"}
 ]
-handlebars.fallbackContexts=[
+handlebars.fallbackContexts = [
 #  the JSON file from Sunrise Design
 #  {"type":"classpath", "path":"/META-INF/resources/webjars/templates"}
 ]
-handlebars.i18n {
-  langs=${play.i18n.langs}
-  bundles=["translations", "home", "catalog", "checkout"]
-}
+handlebars.i18n.bundles = ["translations", "home", "catalog", "checkout"]
 
-checkout.allowedTitles=[
-  {"message":"form.personTitles.mr", "value":"mr"},
-  {"message":"form.personTitles.mrs", "value":"mrs"},
-  {"message":"form.personTitles.ms", "value":"ms"},
-  {"message":"form.personTitles.dr", "value":"dr"}
-]
-checkout.allowedCountries=["DE", "US", "GB", "AT", "CH"]
-checkout.customerServiceNumber="+49 899982996-0"
-
-# common
+# common config
 common.saleCategoryExternalId = "6"
 common.newCategoryExternalId = "1"
-
 
 # home page config
 home.suggestions.externalId = ["29", "37", "22", "28"]
@@ -69,5 +58,14 @@ pop.facet.size = ["one Size","XXS","XS","S","M","L","XL","XXL","XXXL","34","34.5
 
 # product detail page config
 pdp.productSuggestions.count = 4
+
+# checkout pages config
+checkout.allowedTitles = [
+  {"message":"form.personTitles.mr", "value":"mr"},
+  {"message":"form.personTitles.mrs", "value":"mrs"},
+  {"message":"form.personTitles.ms", "value":"ms"},
+  {"message":"form.personTitles.dr", "value":"dr"}
+]
+checkout.customerServiceNumber = "+49 899982996-0"
 
 include "dev"

--- a/purchase/app/purchase/AddressFormBean.java
+++ b/purchase/app/purchase/AddressFormBean.java
@@ -1,6 +1,7 @@
 package purchase;
 
 import com.neovisionaries.i18n.CountryCode;
+import common.contexts.ProjectContext;
 import common.contexts.UserContext;
 import io.sphere.sdk.models.Address;
 import io.sphere.sdk.models.AddressBuilder;
@@ -28,7 +29,8 @@ public class AddressFormBean {
     public AddressFormBean() {
     }
 
-    public AddressFormBean(@Nullable final Address address, final UserContext userContext, final Messages messages, final Configuration configuration) {
+    public AddressFormBean(@Nullable final Address address, final UserContext userContext, final ProjectContext projectContext,
+                           final Messages messages, final Configuration configuration) {
         if (address != null) {
             try {
                 BeanUtils.copyProperties(this, address);
@@ -38,7 +40,7 @@ public class AddressFormBean {
         }
         final SalutationsFieldsBean salutationsFieldsBean = new SalutationsFieldsBean(address, userContext, messages, configuration);
         setSalutations(salutationsFieldsBean);
-        final CountriesFieldsBean countriesFieldsBean = new CountriesFieldsBean(address, userContext, messages, configuration);
+        final CountriesFieldsBean countriesFieldsBean = new CountriesFieldsBean(address, userContext, projectContext, messages);
         setCountries(countriesFieldsBean);
     }
 

--- a/purchase/app/purchase/CheckoutShippingController.java
+++ b/purchase/app/purchase/CheckoutShippingController.java
@@ -50,7 +50,7 @@ public class CheckoutShippingController extends CartController {
         final F.Promise<Cart> cartPromise = getOrCreateCart(userContext, session());
         return cartPromise.map(cart -> {
             final Messages messages = messages(userContext);
-            final CheckoutShippingPageContent content = new CheckoutShippingPageContent(cart, messages, configuration(), userContext, shippingMethods, productDataConfig, reverseRouter());
+            final CheckoutShippingPageContent content = new CheckoutShippingPageContent(cart, messages, configuration(), userContext, projectContext(), shippingMethods, productDataConfig, reverseRouter());
             final SunrisePageData pageData = pageData(userContext, content, ctx());
             return ok(templateService().renderToHtml("checkout-shipping", pageData, userContext.locales()));
         });
@@ -64,7 +64,7 @@ public class CheckoutShippingController extends CartController {
             final CheckoutShippingFormData checkoutShippingFormData = extractBean(request(), CheckoutShippingFormData.class);
             final Form<CheckoutShippingFormData> filledForm = obtainFilledForm(checkoutShippingFormData);
             final Messages messages = messages(userContext);
-            final CheckoutShippingPageContent content = new CheckoutShippingPageContent(checkoutShippingFormData, cart, messages, configuration(), userContext, shippingMethods, productDataConfig, reverseRouter());
+            final CheckoutShippingPageContent content = new CheckoutShippingPageContent(checkoutShippingFormData, cart, messages, configuration(), userContext, projectContext(), shippingMethods, productDataConfig, reverseRouter());
             if (filledForm.hasErrors()) {
                 return F.Promise.pure(badRequest(userContext, filledForm, content));
             } else {

--- a/purchase/app/purchase/CheckoutShippingFormBean.java
+++ b/purchase/app/purchase/CheckoutShippingFormBean.java
@@ -1,7 +1,7 @@
 package purchase;
 
+import common.contexts.ProjectContext;
 import common.contexts.UserContext;
-import common.controllers.ReverseRouter;
 import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.models.Address;
 import io.sphere.sdk.models.Base;
@@ -21,33 +21,38 @@ public class CheckoutShippingFormBean extends Base {
     public CheckoutShippingFormBean() {
     }
 
-    public CheckoutShippingFormBean(final Cart cart, final UserContext userContext, final ShippingMethods shippingMethods, final Messages messages, final Configuration configuration) {
+    public CheckoutShippingFormBean(final Cart cart, final UserContext userContext, final ProjectContext projectContext,
+                                    final ShippingMethods shippingMethods, final Messages messages, final Configuration configuration) {
         final boolean billingAddressDifferentToBillingAddress = Optional.ofNullable(cart.getBillingAddress())
                 .map(Address::getLastName)
                 .map(lastName -> lastName != null)
                 .orElse(false);
         setBillingAddressDifferentToBillingAddress(billingAddressDifferentToBillingAddress);
-        setShippingAddress(new AddressFormBean(cart.getShippingAddress(), userContext, messages, configuration));
-        setBillingAddress(new AddressFormBean(cart.getBillingAddress(), userContext, messages, configuration));
+        setShippingAddress(new AddressFormBean(cart.getShippingAddress(), userContext, projectContext, messages, configuration));
+        setBillingAddress(new AddressFormBean(cart.getBillingAddress(), userContext, projectContext, messages, configuration));
         setShippingMethods(new ShippingMethodsFormBean(cart, shippingMethods));
     }
 
-    public CheckoutShippingFormBean(final CheckoutShippingFormData checkoutShippingFormData, final UserContext userContext, final ShippingMethods shippingMethods, final Messages messages, final Configuration configuration) {
+    public CheckoutShippingFormBean(final CheckoutShippingFormData checkoutShippingFormData, final UserContext userContext,
+                                    final ProjectContext projectContext, final ShippingMethods shippingMethods,
+                                    final Messages messages, final Configuration configuration) {
         setBillingAddressDifferentToBillingAddress(checkoutShippingFormData.isBillingAddressDifferentToBillingAddress());
 
-        final AddressFormBean shippingAddress = createShippingAddressFormBean(checkoutShippingFormData, userContext, messages, configuration);
+        final AddressFormBean shippingAddress = createShippingAddressFormBean(checkoutShippingFormData, userContext, projectContext, messages, configuration);
         setShippingAddress(shippingAddress);
 
-        final AddressFormBean billingAddress = createBillingAddressFormBean(checkoutShippingFormData, userContext, messages, configuration);
+        final AddressFormBean billingAddress = createBillingAddressFormBean(checkoutShippingFormData, userContext, projectContext, messages, configuration);
         setBillingAddress(billingAddress);
 
         setShippingMethods(new ShippingMethodsFormBean(checkoutShippingFormData, shippingMethods));
     }
 
-    private AddressFormBean createShippingAddressFormBean(final CheckoutShippingFormData checkoutShippingFormData, final UserContext userContext, final Messages messages, final Configuration configuration) {
+    private AddressFormBean createShippingAddressFormBean(final CheckoutShippingFormData checkoutShippingFormData,
+                                                          final UserContext userContext, final ProjectContext projectContext,
+                                                          final Messages messages, final Configuration configuration) {
         final AddressFormBean shippingAddress = new AddressFormBean();
         shippingAddress.setSalutations(new SalutationsFieldsBean(checkoutShippingFormData.getTitleShipping(), messages, configuration));
-        shippingAddress.setCountries(new CountriesFieldsBean(checkoutShippingFormData.getCountryShipping(), userContext, configuration));
+        shippingAddress.setCountries(new CountriesFieldsBean(checkoutShippingFormData.getCountryShipping(), userContext, projectContext));
         shippingAddress.setFirstName(checkoutShippingFormData.getFirstNameShipping());
         shippingAddress.setLastName(checkoutShippingFormData.getLastNameShipping());
         shippingAddress.setStreetName(checkoutShippingFormData.getStreetNameShipping());
@@ -61,10 +66,12 @@ public class CheckoutShippingFormBean extends Base {
         return shippingAddress;
     }
 
-    private AddressFormBean createBillingAddressFormBean(final CheckoutShippingFormData checkoutShippingFormData, final UserContext userContext, final Messages messages, final Configuration configuration) {
+    private AddressFormBean createBillingAddressFormBean(final CheckoutShippingFormData checkoutShippingFormData,
+                                                         final UserContext userContext, final ProjectContext projectContext,
+                                                         final Messages messages, final Configuration configuration) {
         final AddressFormBean billingAddress = new AddressFormBean();
         billingAddress.setSalutations(new SalutationsFieldsBean(checkoutShippingFormData.getTitleBilling(), messages, configuration));
-        billingAddress.setCountries(new CountriesFieldsBean(checkoutShippingFormData.getCountryBilling(), userContext, configuration));
+        billingAddress.setCountries(new CountriesFieldsBean(checkoutShippingFormData.getCountryBilling(), userContext, projectContext));
         billingAddress.setFirstName(checkoutShippingFormData.getFirstNameBilling());
         billingAddress.setLastName(checkoutShippingFormData.getLastNameBilling());
         billingAddress.setStreetName(checkoutShippingFormData.getStreetNameBilling());

--- a/purchase/app/purchase/CheckoutShippingPageContent.java
+++ b/purchase/app/purchase/CheckoutShippingPageContent.java
@@ -1,5 +1,6 @@
 package purchase;
 
+import common.contexts.ProjectContext;
 import common.contexts.UserContext;
 import common.controllers.ReverseRouter;
 import common.models.ProductDataConfig;
@@ -15,18 +16,18 @@ public class CheckoutShippingPageContent extends CheckoutPageContent {
     }
 
     public CheckoutShippingPageContent(final Cart cart, final Messages messages, final Configuration configuration,
-                                       final UserContext userContext, final ShippingMethods shippingMethods,
+                                       final UserContext userContext, final ProjectContext projectContext, final ShippingMethods shippingMethods,
                                        final ProductDataConfig productDataConfig, final ReverseRouter reverseRouter) {
         fillDefaults(cart, userContext, productDataConfig, messages, reverseRouter);
-        setShippingForm(new CheckoutShippingFormBean(cart, userContext, shippingMethods, messages, configuration));
+        setShippingForm(new CheckoutShippingFormBean(cart, userContext, projectContext, shippingMethods, messages, configuration));
     }
 
     public CheckoutShippingPageContent(final CheckoutShippingFormData filledForm, final Cart cart, final Messages messages,
-                                       final Configuration configuration, final UserContext userContext,
+                                       final Configuration configuration, final UserContext userContext, final ProjectContext projectContext,
                                        final ShippingMethods shippingMethods, final ProductDataConfig productDataConfig,
                                        final ReverseRouter reverseRouter) {
         fillDefaults(cart, userContext, productDataConfig, messages, reverseRouter);
-        setShippingForm(new CheckoutShippingFormBean(filledForm, userContext, shippingMethods, messages, configuration));
+        setShippingForm(new CheckoutShippingFormBean(filledForm, userContext, projectContext, shippingMethods, messages, configuration));
     }
 
     private void fillDefaults(final Cart cart, final UserContext userContext, final ProductDataConfig productDataConfig, final Messages messages, final ReverseRouter reverseRouter) {

--- a/purchase/app/purchase/CountriesFieldsBean.java
+++ b/purchase/app/purchase/CountriesFieldsBean.java
@@ -1,10 +1,10 @@
 package purchase;
 
 import com.neovisionaries.i18n.CountryCode;
+import common.contexts.ProjectContext;
 import common.contexts.UserContext;
 import common.models.SelectableData;
 import io.sphere.sdk.models.Address;
-import play.Configuration;
 import play.i18n.Messages;
 
 import javax.annotation.Nullable;
@@ -20,24 +20,24 @@ public class CountriesFieldsBean {
     public CountriesFieldsBean() {
     }
 
-    public CountriesFieldsBean(@Nullable final Address address, final UserContext userContext, final Messages messages, final Configuration configuration) {
+    public CountriesFieldsBean(@Nullable final Address address, final UserContext userContext, final ProjectContext projectContext, final Messages messages) {
         final String selectedCountry = Optional.ofNullable(address).map(Address::getCountry).map(CountryCode::getAlpha2).orElse(null);
-        fill(userContext, configuration, selectedCountry);
+        fill(userContext, projectContext, selectedCountry);
     }
 
-    private void fill(final UserContext userContext, final Configuration configuration, final String selectedCountry) {
-        final List<SelectableData> selectableDataList = configuration.getStringList("checkout.allowedCountries").stream().map(countryCode -> {
+    private void fill(final UserContext userContext, final ProjectContext projectContext, final String selectedCountry) {
+        final List<SelectableData> selectableDataList = projectContext.countries().stream().map(countryCode -> {
             final SelectableData selectableData = new SelectableData();
-            selectableData.setLabel(CountryCode.valueOf(countryCode).toLocale().getDisplayCountry(userContext.locale()));
-            selectableData.setValue(countryCode);
-            selectableData.setSelected(countryCode.equals(selectedCountry));
+            selectableData.setLabel(countryCode.toLocale().getDisplayCountry(userContext.locale()));
+            selectableData.setValue(countryCode.getAlpha2());
+            selectableData.setSelected(countryCode.getAlpha2().equals(selectedCountry));
             return selectableData;
         }).collect(toList());
         setList(selectableDataList);
     }
 
-    public CountriesFieldsBean(@Nullable final String country, final UserContext userContext, final Configuration configuration) {
-        fill(userContext, configuration, country);
+    public CountriesFieldsBean(@Nullable final String country, final UserContext userContext, final ProjectContext projectContext) {
+        fill(userContext, projectContext, country);
     }
 
 


### PR DESCRIPTION
@schleichardt please review.
Now countries and languages are by default coming from the project info, unless defined in configuration file otherwise. This allows the full control with the CTP project but still provides the flexibility of defining your own.
This affected Handlebars, which now tries to load the languages coming from the project/config.
Also affects the checkout, which loads the countries from project/config.
And of course the language/country list, which is filled with info coming from project/config.